### PR TITLE
Index compression + indexing performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,13 @@ endif
 
 export CGO_CFLAGS := -DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_OMIT_SHARED_CACHE -DSQLITE_USE_ALLOCA
 
+SQLITE_TAGS := fts5,sqlite_omit_load_extension
+
 letarette: generate snowball
-	go build -ldflags="$(STAMP) $(LDFLAGS)" -v -tags "fts5,sqlite_omit_load_extension" -o letarette ./cmd/worker
+	go build -ldflags="$(STAMP) $(LDFLAGS)" -v -tags "$(SQLITE_TAGS)" -o letarette ./cmd/worker
 
 lrcli: client snowball
-	go build -ldflags="$(STAMP) $(LDFLAGS)" -v -tags "fts5,dbstats,sqlite_omit_load_extension" ./cmd/lrcli
+	go build -ldflags="$(STAMP) $(LDFLAGS)" -v -tags "$(SQLITE_TAGS),dbstats" ./cmd/lrcli
 
 tinysrv: client
 	go build -ldflags="$(LDFLAGS)" -v ./cmd/tinysrv
@@ -34,7 +36,7 @@ $(SNOWBALL)/README:
 	git submodule init && git submodule update --recursive
 
 test:
-	go test -tags "fts5" ./internal/letarette ./pkg/*
+	go test -tags "$(SQLITE_TAGS)" ./internal/letarette ./pkg/*
 
 generate:
 	go generate internal/letarette/db.go

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ifdef STATIC
 LDFLAGS := -linkmode external -extldflags -static
 endif
 
-export CGO_CFLAGS := -DSQLITE_OMIT_LOAD_EXTENSION
+export CGO_CFLAGS := -DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_OMIT_SHARED_CACHE -DSQLITE_USE_ALLOCA
 
 letarette: generate snowball
 	go build -ldflags="$(STAMP) $(LDFLAGS)" -v -tags "fts5,sqlite_omit_load_extension" -o letarette ./cmd/worker

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,24 @@
 all: letarette lrcli lrload
 
-LDFLAGS := $(shell ./stamp.sh github.com/erkkah/letarette/internal/letarette)
+STAMP := $(shell ./stamp.sh github.com/erkkah/letarette/internal/letarette)
+
+ifdef STATIC
+LDFLAGS := -linkmode external -extldflags -static
+endif
+
+export CGO_CFLAGS := -DSQLITE_OMIT_LOAD_EXTENSION
 
 letarette: generate snowball
-	go build -ldflags="$(LDFLAGS)" -v -tags "fts5" -o letarette ./cmd/worker
-
-tinysrv: client
-	go build -v ./cmd/tinysrv
-
-lrload: client
-	go build -v ./cmd/lrload
+	go build -ldflags="$(STAMP) $(LDFLAGS)" -v -tags "fts5,sqlite_omit_load_extension" -o letarette ./cmd/worker
 
 lrcli: client snowball
-	go build -ldflags="$(LDFLAGS)" -v -tags "fts5,dbstats" ./cmd/lrcli
+	go build -ldflags="$(STAMP) $(LDFLAGS)" -v -tags "fts5,dbstats,sqlite_omit_load_extension" ./cmd/lrcli
+
+tinysrv: client
+	go build -ldflags="$(LDFLAGS)" -v ./cmd/tinysrv
+
+lrload: client
+	go build -ldflags="$(LDFLAGS)" -v ./cmd/lrload
 
 client:
 	go build -v ./pkg/client

--- a/cmd/lrcli/main.go
+++ b/cmd/lrcli/main.go
@@ -59,6 +59,7 @@ var cmdline struct {
 	Stats        bool
 	Check        bool
 	Pgsize       bool
+	Compress     bool
 	Size         int `docopt:"<size>"`
 	Rebuild      bool
 	Optimize     bool
@@ -85,6 +86,7 @@ Usage:
     lrcli index stats
     lrcli index check
     lrcli index pgsize <size>
+    lrcli index compress
     lrcli index optimize
     lrcli index rebuild
     lrcli index forcestemmer
@@ -145,6 +147,8 @@ Options:
 				logger.Warning.Printf("Index and config stemmer settings mismatch. Re-build index or force changes.")
 			}
 			checkIndex(db)
+		case cmdline.Compress:
+			compressIndex(db)
 		case cmdline.Pgsize:
 			setIndexPageSize(db, cmdline.Size)
 		case cmdline.Stats:
@@ -417,6 +421,18 @@ func sql(db letarette.Database, statement string) {
 	fmt.Printf("Executed in %vs\n", duration)
 	for _, v := range result {
 		fmt.Println(v)
+	}
+}
+
+func compressIndex(db letarette.Database) {
+	s := getSpinner("Compressing index", "OK\n")
+	s.Start()
+	defer s.Stop()
+
+	ctx := context.Background()
+	err := letarette.CompressIndex(ctx, db)
+	if err != nil {
+		logger.Error.Printf("Failed to compress index: %v", err)
 	}
 }
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -49,9 +49,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	letarette.ExposeMetrics(cfg.MetricsPort)
-
 	logger.Info.Printf("Starting Letarette %s (%s)", letarette.Tag, letarette.Revision)
+
+	letarette.ExposeMetrics(cfg.MetricsPort)
+	profiler, err := letarette.StartProfiler(cfg)
+	if err != nil {
+		logger.Error.Printf("Failed to start profiler: %v", err)
+		os.Exit(1)
+	}
+	defer profiler.Close()
+
 	logger.Info.Printf("Connecting to nats server at %q\n", cleanURLs(cfg.Nats.URLS))
 
 	options := []nats.Option{

--- a/internal/compress/compress.c
+++ b/internal/compress/compress.c
@@ -1,0 +1,129 @@
+/*
+** 2014-06-13
+**
+** The author disclaims copyright to this source code.  In place of
+** a legal notice, here is a blessing:
+**
+**    May you do good and not evil.
+**    May you find forgiveness for yourself and forgive others.
+**    May you share freely, never taking more than you give.
+**
+******************************************************************************
+**
+** This SQLite extension implements SQL compression functions
+** compress() and uncompress() using ZLIB.
+*/
+#include "sqlite3ext.h"
+SQLITE_EXTENSION_INIT1
+#include <zlib.h>
+
+/*
+** Implementation of the "compress(X)" SQL function.  The input X is
+** compressed using zLib and the output is returned.
+**
+** The output is a BLOB that begins with a variable-length integer that
+** is the input size in bytes (the size of X before compression).  The
+** variable-length integer is implemented as 1 to 5 bytes.  There are
+** seven bits per integer stored in the lower seven bits of each byte.
+** More significant bits occur first.  The most significant bit (0x80)
+** is a flag to indicate the end of the integer.
+**
+** This function, SQLAR, and ZIP all use the same "deflate" compression
+** algorithm, but each is subtly different:
+**
+**   *  ZIP uses raw deflate.
+**
+**   *  SQLAR uses the "zlib format" which is raw deflate with a two-byte
+**      algorithm-identification header and a four-byte checksum at the end.
+**
+**   *  This utility uses the "zlib format" like SQLAR, but adds the variable-
+**      length integer uncompressed size value at the beginning.
+**
+** This function might be extended in the future to support compression
+** formats other than deflate, by providing a different algorithm-id
+** mark following the variable-length integer size parameter.
+*/
+static void compressFunc(
+  sqlite3_context *context,
+  int argc,
+  sqlite3_value **argv
+){
+  const unsigned char *pIn;
+  unsigned char *pOut;
+  unsigned int nIn;
+  unsigned long int nOut;
+  unsigned char x[8];
+  int rc;
+  int i, j;
+
+  pIn = sqlite3_value_blob(argv[0]);
+  nIn = sqlite3_value_bytes(argv[0]);
+  nOut = 13 + nIn + (nIn+999)/1000;
+  pOut = sqlite3_malloc( nOut+5 );
+  for(i=4; i>=0; i--){
+    x[i] = (nIn >> (7*(4-i)))&0x7f;
+  }
+  for(i=0; i<4 && x[i]==0; i++){}
+  for(j=0; i<=4; i++, j++) pOut[j] = x[i];
+  pOut[j-1] |= 0x80;
+  rc = compress(&pOut[j], &nOut, pIn, nIn);
+  if( rc==Z_OK ){
+    sqlite3_result_blob(context, pOut, nOut+j, sqlite3_free);
+  }else{
+    sqlite3_free(pOut);
+  }
+}
+
+/*
+** Implementation of the "uncompress(X)" SQL function.  The argument X
+** is a blob which was obtained from compress(Y).  The output will be
+** the value Y.
+*/
+static void uncompressFunc(
+  sqlite3_context *context,
+  int argc,
+  sqlite3_value **argv
+){
+  const unsigned char *pIn;
+  unsigned char *pOut;
+  unsigned int nIn;
+  unsigned long int nOut;
+  int rc;
+  int i;
+
+  pIn = sqlite3_value_blob(argv[0]);
+  nIn = sqlite3_value_bytes(argv[0]);
+  nOut = 0;
+  for(i=0; i<nIn && i<5; i++){
+    nOut = (nOut<<7) | (pIn[i]&0x7f);
+    if( (pIn[i]&0x80)!=0 ){ i++; break; }
+  }
+  pOut = sqlite3_malloc( nOut+1 );
+  rc = uncompress(pOut, &nOut, &pIn[i], nIn-i);
+  if( rc==Z_OK ){
+    sqlite3_result_blob(context, pOut, nOut, sqlite3_free);
+  }else{
+    sqlite3_free(pOut);
+  }
+}
+
+
+#ifdef _WIN32
+__declspec(dllexport)
+#endif
+int sqlite3_compress_init(
+  sqlite3 *db, 
+  char **pzErrMsg, 
+  const sqlite3_api_routines *pApi
+){
+  int rc = SQLITE_OK;
+  SQLITE_EXTENSION_INIT2(pApi);
+  (void)pzErrMsg;  /* Unused parameter */
+  rc = sqlite3_create_function(db, "compress", 1, SQLITE_UTF8, 0,
+                               compressFunc, 0, 0);
+  if( rc==SQLITE_OK ){
+    rc = sqlite3_create_function(db, "uncompress", 1, SQLITE_UTF8, 0,
+                                 uncompressFunc, 0, 0);
+  }
+  return rc;
+}

--- a/internal/compress/compress.c
+++ b/internal/compress/compress.c
@@ -12,6 +12,16 @@
 **
 ** This SQLite extension implements SQL compression functions
 ** compress() and uncompress() using ZLIB.
+**
+** 2020-01-08
+** Letarette-specific additions:
+**
+**   *   the "compress(X)" function handles errors by returning error
+**
+**   *   the "uncompress(X)" function handles errors by returning error, or the input if it is not in zlib format
+**
+**   *   Added "iscompressed(X)" that checks if the input is a compressed stream as returned from "compress(X)"
+**
 */
 #include "sqlite3ext.h"
 SQLITE_EXTENSION_INIT1
@@ -71,6 +81,7 @@ static void compressFunc(
     sqlite3_result_blob(context, pOut, nOut+j, sqlite3_free);
   }else{
     sqlite3_free(pOut);
+    sqlite3_result_error_code(context, SQLITE_ERROR);
   }
 }
 
@@ -78,6 +89,9 @@ static void compressFunc(
 ** Implementation of the "uncompress(X)" SQL function.  The argument X
 ** is a blob which was obtained from compress(Y).  The output will be
 ** the value Y.
+**
+** If the input is not a compressed stream as returned by "compress(X)",
+** the unmodified input is returned.
 */
 static void uncompressFunc(
   sqlite3_context *context,
@@ -100,11 +114,43 @@ static void uncompressFunc(
   }
   pOut = sqlite3_malloc( nOut+1 );
   rc = uncompress(pOut, &nOut, &pIn[i], nIn-i);
-  if( rc==Z_OK ){
+  if( rc == Z_OK ){
     sqlite3_result_blob(context, pOut, nOut, sqlite3_free);
   }else{
     sqlite3_free(pOut);
+    if ( rc == Z_DATA_ERROR || rc == Z_STREAM_ERROR ) {
+      sqlite3_result_blob(context, pIn, nIn, 0);
+    } else {
+      sqlite3_result_error_code(context, SQLITE_ERROR);
+    }
   }
+}
+
+/*
+** Implementation of the "iscompressed(X)" SQL function. If the argument X
+** is a blob which was obtained from compress(Y), the output will be true.
+*/
+static void isCompressedFunc(
+  sqlite3_context *context,
+  int argc,
+  sqlite3_value **argv
+){
+  const unsigned char *pIn;
+  unsigned char *pOut;
+  unsigned int nIn;
+  unsigned long int nOut;
+  int rc;
+  int i;
+
+  pIn = sqlite3_value_blob(argv[0]);
+  nIn = sqlite3_value_bytes(argv[0]);
+  nOut = 0;
+  for(i=0; i<nIn && i<5; i++){
+    nOut = (nOut<<7) | (pIn[i]&0x7f);
+    if( (pIn[i]&0x80)!=0 ){ i++; break; }
+  }
+
+  sqlite3_result_int(context, (nOut != 0) && (pIn[i] == 0x78));
 }
 
 
@@ -121,9 +167,18 @@ int sqlite3_compress_init(
   (void)pzErrMsg;  /* Unused parameter */
   rc = sqlite3_create_function(db, "compress", 1, SQLITE_UTF8, 0,
                                compressFunc, 0, 0);
-  if( rc==SQLITE_OK ){
-    rc = sqlite3_create_function(db, "uncompress", 1, SQLITE_UTF8, 0,
-                                 uncompressFunc, 0, 0);
+  if( rc != SQLITE_OK ){
+    return rc;
+  }
+  rc = sqlite3_create_function(db, "uncompress", 1, SQLITE_UTF8, 0,
+                               uncompressFunc, 0, 0);
+  if( rc != SQLITE_OK ){
+    return rc;
+  }
+  rc = sqlite3_create_function(db, "iscompressed", 1, SQLITE_UTF8, 0,
+                               isCompressedFunc, 0, 0);
+  if( rc != SQLITE_OK ){
+    return rc;
   }
   return rc;
 }

--- a/internal/compress/compress.go
+++ b/internal/compress/compress.go
@@ -1,0 +1,48 @@
+// Copyright 2019 Erik Agsjö
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compress
+
+// #cgo CFLAGS: -DSQLITE_CORE
+// #cgo darwin CFLAGS: -I/usr/local/opt/sqlite/include
+// #cgo LDFLAGS: -lsqlite3 -lz
+// #cgo darwin LDFLAGS: -L/usr/local/opt/sqlite/lib
+// #include "compress.h"
+import "C"
+import (
+	"fmt"
+	"reflect"
+	"unsafe"
+
+	"github.com/mattn/go-sqlite3"
+)
+
+// Init registers the spellfix extension with a connection.
+func Init(conn *sqlite3.SQLiteConn) error {
+	db := dbFromConnection(conn)
+	var errorMessage *C.char
+	var nullRoutines = (*C.sqlite3_api_routines)(nil)
+	result := C.sqlite3_compress_init(db, &errorMessage, nullRoutines)
+	if result != C.SQLITE_OK {
+		message := C.GoString(errorMessage)
+		return fmt.Errorf("Failed to init compress extension: %s", message)
+	}
+	return nil
+}
+
+func dbFromConnection(conn *sqlite3.SQLiteConn) *C.sqlite3 {
+	dbVal := reflect.ValueOf(conn).Elem().FieldByName("db")
+	dbPtr := unsafe.Pointer(dbVal.Pointer())
+	return (*C.sqlite3)(dbPtr)
+}

--- a/internal/compress/compress.h
+++ b/internal/compress/compress.h
@@ -1,0 +1,17 @@
+// Copyright 2019 Erik Agsjö
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sqlite3.h>
+
+int sqlite3_compress_init(sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi);

--- a/internal/letarette/config.go
+++ b/internal/letarette/config.go
@@ -44,14 +44,15 @@ type Config struct {
 	}
 	Index struct {
 		Spaces         []string `required:"true" default:"docs"`
-		ChunkSize      uint16   `default:"250"`
-		MaxOutstanding uint16   `split_words:"true" default:"25"`
+		ListSize       uint16   `default:"250"`
+		ReqSize        uint16   `default:"25"`
+		MaxOutstanding uint16   `split_words:"true" default:"2"`
 		Wait           struct {
-			Interest        time.Duration `default:"5s"`
-			DocumentRefetch time.Duration `default:"1s"`
-			Document        time.Duration `default:"20s"`
-			Cycle           time.Duration `default:"100ms"`
-			EmptyCycle      time.Duration `default:"5s"`
+			Cycle      time.Duration `default:"5ms"`
+			EmptyCycle time.Duration `default:"5s"`
+			Interest   time.Duration `default:"5s"`
+			Document   time.Duration `default:"20s"`
+			Refetch    time.Duration `default:"1s"`
 		}
 		Disable  bool `default:"false"`
 		Compress bool `default:"false"`
@@ -78,6 +79,13 @@ type Config struct {
 	ShardgroupSize  uint16 `ignored:"true"`
 	ShardgroupIndex uint16 `ignored:"true"`
 	MetricsPort     uint16 `split_words:"true" default:"8000" desc:"internal"`
+	Profile         struct {
+		HTTP  int    `desc:"internal"`
+		CPU   string `desc:"internal"`
+		Mem   string `desc:"internal"`
+		Block string `desc:"internal"`
+		Mutex string `desc:"internal"`
+	}
 }
 
 const prefix = "LETARETTE"
@@ -124,10 +132,9 @@ func LoadConfig() (cfg Config, err error) {
 
 func validateIndexDurations(cfg Config) bool {
 	return (cfg.Index.Wait.Interest > time.Millisecond*20 &&
-		cfg.Index.Wait.Cycle > time.Millisecond &&
 		cfg.Index.Wait.Cycle < cfg.Index.Wait.EmptyCycle &&
-		cfg.Index.Wait.DocumentRefetch > time.Millisecond*20 &&
-		cfg.Index.Wait.DocumentRefetch < cfg.Index.Wait.Document)
+		cfg.Index.Wait.Refetch > time.Millisecond*20 &&
+		cfg.Index.Wait.Refetch < cfg.Index.Wait.Document)
 }
 
 var usageFormat = fmt.Sprintf("{{$t:=\"\t\"}}%s\n%s (%s)\n",

--- a/internal/letarette/config.go
+++ b/internal/letarette/config.go
@@ -53,7 +53,8 @@ type Config struct {
 			Cycle           time.Duration `default:"100ms"`
 			EmptyCycle      time.Duration `default:"5s"`
 		}
-		Disable bool `default:"false"`
+		Disable  bool `default:"false"`
+		Compress bool `default:"false"`
 	}
 	Spelling struct {
 		MinFrequency int `split_words:"true" default:"5"`

--- a/internal/letarette/indextools.go
+++ b/internal/letarette/indextools.go
@@ -150,6 +150,17 @@ func RebuildIndex(dbo Database) error {
 	return nil
 }
 
+// VacuumIndex runs vacuum on the database to reclaim space
+func VacuumIndex(dbo Database) error {
+	db := dbo.(*database)
+	sql := db.getRawDB()
+	_, err := sql.Exec(`vacuum`)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // IndexOptimizer is used to run step-wise index optimization.
 // The instance must be closed by calling Close() to return
 // the database connection to the pool.

--- a/internal/letarette/migrations/1_init.up.sql
+++ b/internal/letarette/migrations/1_init.up.sql
@@ -40,7 +40,8 @@ create table if not exists spaces(
 create table if not exists interest(
     spaceID integer not null,
     docID text not null,
-    state integer not null, updatedNanos integer not null default 0,
+    state integer not null,
+    updatedNanos integer not null default 0,
     unique(spaceID, docID)
     foreign key (spaceID) references spaces(spaceID)
 );

--- a/internal/letarette/migrations/3_compress.down.sql
+++ b/internal/letarette/migrations/3_compress.down.sql
@@ -1,0 +1,29 @@
+drop view cdocs;
+
+drop table fts;
+
+create virtual table fts using fts5(
+    title, txt, content='docs', content_rowid='id',
+    tokenize='snowball', prefix='2 3 4'
+);
+
+drop trigger docs_ai;
+
+create trigger docs_ai after insert on docs begin
+    insert into fts(rowid, title, txt) values (new.id, new.title, new.txt);
+end;
+
+drop trigger docs_ad;
+
+create trigger docs_ad after delete on docs begin
+    insert into fts(fts, rowid, title, txt) values ('delete', old.id, old.title, old.txt);
+end;
+
+drop trigger docs_au;
+
+create trigger docs_au after update on docs begin
+    insert into fts(fts, rowid, title, txt) values ('delete', old.id, old.title, old.txt);
+    insert into fts(rowid, title, txt) values (new.id, new.title, uncompress(new.txt));
+end;
+
+insert into fts(fts) values("rebuild");

--- a/internal/letarette/migrations/3_compress.up.sql
+++ b/internal/letarette/migrations/3_compress.up.sql
@@ -1,0 +1,32 @@
+create view if not exists cdocs (
+    id, title, txt
+) as
+select id, title, uncompress(txt) from docs;
+
+drop table fts;
+
+create virtual table fts using fts5(
+    title, txt, content='cdocs', content_rowid='id',
+    tokenize='snowball', prefix='2 3 4'
+);
+
+drop trigger docs_ai;
+
+create trigger docs_ai after insert on docs begin
+    insert into fts(rowid, title, txt) values (new.id, new.title, uncompress(new.txt));
+end;
+
+drop trigger docs_ad;
+
+create trigger docs_ad after delete on docs begin
+    insert into fts(fts, rowid, title, txt) values ('delete', old.id, old.title, uncompress(old.txt));
+end;
+
+drop trigger docs_au;
+
+create trigger docs_au after update on docs begin
+    insert into fts(fts, rowid, title, txt) values ('delete', old.id, old.title, uncompress(old.txt));
+    insert into fts(rowid, title, txt) values (new.id, new.title, uncompress(new.txt));
+end;
+
+insert into fts(fts) values("rebuild");

--- a/internal/letarette/profiling.go
+++ b/internal/letarette/profiling.go
@@ -1,0 +1,115 @@
+package letarette
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"runtime"
+	"runtime/pprof"
+
+	"github.com/erkkah/letarette/pkg/logger"
+
+	// Pull in pprof HTTP handler
+	_ "net/http/pprof"
+)
+
+// Profiler wraps native profiling tools
+type Profiler struct {
+	cpuWriter *os.File
+	memWriter *os.File
+
+	blockProfile *pprof.Profile
+	blockWriter  *os.File
+
+	mutexProfile *pprof.Profile
+	mutexWriter  *os.File
+}
+
+// StartProfiler starts a profiler if setup in the config
+func StartProfiler(cfg Config) (*Profiler, error) {
+	profiler := &Profiler{}
+
+	if cfg.Profile.HTTP != 0 {
+		runtime.SetBlockProfileRate(100)
+		runtime.SetMutexProfileFraction(5)
+		go func() {
+			logger.Info.Printf("Starting profiler HTTP listener on port %d", cfg.Profile.HTTP)
+			log.Println(http.ListenAndServe(fmt.Sprintf("localhost:%d", cfg.Profile.HTTP), nil))
+		}()
+	}
+
+	if cfg.Profile.CPU != "" {
+		logger.Info.Printf("Starting CPU profiler writer to %s", cfg.Profile.CPU)
+		f, err := os.Create(cfg.Profile.CPU)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to create CPU profile: %v", err)
+		}
+		profiler.cpuWriter = f
+		if err = pprof.StartCPUProfile(f); err != nil {
+			return nil, fmt.Errorf("Failed to start CPU profile: %v", err)
+		}
+	}
+
+	if cfg.Profile.Mem != "" {
+		logger.Info.Printf("Starting memory profiler writer to %s", cfg.Profile.Mem)
+		f, err := os.Create(cfg.Profile.Mem)
+		if err != nil {
+			log.Fatalf("Failed to create memory profile: %v", err)
+		}
+		profiler.memWriter = f
+	}
+
+	if cfg.Profile.Block != "" {
+		logger.Info.Printf("Starting block profiler writer to %s", cfg.Profile.Block)
+		runtime.SetBlockProfileRate(1)
+		f, err := os.Create(cfg.Profile.Block)
+		if err != nil {
+			log.Fatalf("Failed to create block profile: %v", err)
+		}
+		p := pprof.Lookup("block")
+
+		profiler.blockProfile = p
+		profiler.blockWriter = f
+	}
+
+	if cfg.Profile.Mutex != "" {
+		logger.Info.Printf("Starting mutex profiler writer to %s", cfg.Profile.Mutex)
+		runtime.SetMutexProfileFraction(1000)
+		f, err := os.Create(cfg.Profile.Mutex)
+		if err != nil {
+			log.Fatalf("Failed to create mutex profile: %v", err)
+		}
+		p := pprof.Lookup("mutex")
+
+		profiler.mutexProfile = p
+		profiler.mutexWriter = f
+	}
+
+	return profiler, nil
+}
+
+// Close finishes profiling
+func (p *Profiler) Close() error {
+	if p.cpuWriter != nil {
+		pprof.StopCPUProfile()
+		p.cpuWriter.Close()
+	}
+
+	if p.memWriter != nil {
+		runtime.GC()
+		if err := pprof.WriteHeapProfile(p.memWriter); err != nil {
+			return fmt.Errorf("could not write memory profile: %v", err)
+		}
+		p.memWriter.Close()
+	}
+
+	if p.blockProfile != nil {
+		p.blockProfile.WriteTo(p.blockWriter, 1)
+	}
+
+	if p.mutexProfile != nil {
+		p.mutexProfile.WriteTo(p.mutexWriter, 1)
+	}
+	return nil
+}

--- a/internal/letarette/queries/search_1.sql
+++ b/internal/letarette/queries/search_1.sql
@@ -36,7 +36,7 @@ select
         gettokens(fts,
             case matchColumn
                 when 0 then docs.title
-                when 1 then docs.txt
+                when 1 then uncompress(docs.txt)
             end,
             max(matchOffset-1, 0), 10),
         X'0A', " "

--- a/internal/letarette/queries/search_2.sql
+++ b/internal/letarette/queries/search_2.sql
@@ -36,7 +36,7 @@ select
         gettokens(fts,
             case matchColumn
                 when 0 then docs.title
-                when 1 then docs.txt
+                when 1 then uncompress(docs.txt)
             end,
             max(matchOffset-1, 0), 10),
         X'0A', " "


### PR DESCRIPTION
Adds support for compressing the raw text part of the index using zlib.

Contains tweaks to increase indexing performance, including:
* higher autocheckpoint watermark
* removing unnecessary mutex check
* prepared statements
* improved intake pipelining (needs more work!)

Adds helper to simplify profiling.
`lrcli` now runs "vacuum" after index optimizations.